### PR TITLE
refactored getWikiLink

### DIFF
--- a/public_html/appeal.php
+++ b/public_html/appeal.php
@@ -318,12 +318,12 @@ if (isset($_GET['action'])) {
 <div class="linklist">Account links:
 <ul>
   <li><a href="<?php echo getWikiLink($appeal->getUserPage(), $user->getUseSecure()); ?>" target="_blank">User Page</a></li>
-  <li><a href="<?php echo getWikiLink("User_talk:" . urlencode($appeal->getCommonName()), $user->getUseSecure()); ?>" target="_blank">User Talk Page</a></li>
-  <li><a href="<?php echo getWikiLink("Special:Log/block", $user->getUseSecure(), "page=User:" . urlencode($appeal->getCommonName())); ?>" target="_blank">Block Log</a></li>
-  <li><a href="<?php echo getWikiLink("Special:BlockList", $user->getUseSecure(), "wpTarget=" . urlencode($appeal->getCommonName()) . "&limit=50"); ?>" target="_blank">Find block</a></li> 
-  <li><a href="<?php echo getWikiLink("Special:Contributions/" . urlencode($appeal->getCommonName()), $user->getUseSecure()); ?>" target="_blank">Contribs</a></li>
-  <li><a href="<?php echo getWikiLink("Special:Unblock/" . urlencode($appeal->getCommonName()), $user->getUseSecure()); ?>" target="_blank">Unblock</a></li> 
-  <li><a href="<?php echo getWikiLink("Special:UserLogin", $user->getUseSecure(), "type=signup"); ?>" target="_blank">Create Account</a></li>
+  <li><a href="<?php echo getWikiLink("User_talk:" . $appeal->getCommonName(), $user->getUseSecure()); ?>" target="_blank">User Talk Page</a></li>
+  <li><a href="<?php echo getWikiLink("Special:Log/block", $user->getUseSecure(), array('page' => "User:" . $appeal->getCommonName())); ?>" target="_blank">Block Log</a></li>
+  <li><a href="<?php echo getWikiLink("Special:BlockList", $user->getUseSecure(), array('wpTarget' => $appeal->getCommonName(), 'limit' => '50')); ?>" target="_blank">Find block</a></li> 
+  <li><a href="<?php echo getWikiLink("Special:Contributions/" . $appeal->getCommonName(), $user->getUseSecure()); ?>" target="_blank">Contribs</a></li>
+  <li><a href="<?php echo getWikiLink("Special:Unblock/" . $appeal->getCommonName(), $user->getUseSecure()); ?>" target="_blank">Unblock</a></li> 
+  <li><a href="<?php echo getWikiLink("Special:UserLogin", $user->getUseSecure(), array('type'=>"signup")); ?>" target="_blank">Create Account</a></li>
 </ul>
 </div>
 Request timestamp: <?php echo $appeal->getTimestamp(); ?><br>
@@ -336,18 +336,18 @@ Appeals by this IP: <a href="search.php?id=<?php echo $appeal->getID(); ?>"><b><
 Status: <b><?php echo $appeal->getStatus(); ?></b><br>
 <div class="linklist">Blocking Admin:
 <ul>
-  <li><a href="<?php echo getWikiLink("User:" . urlencode($appeal->getBlockingAdmin()), $user->getUseSecure()); ?>" target=\"_blank\"><?php echo $appeal->getBlockingAdmin(); ?></a></li>
-  <li><a href="<?php echo getWikiLink("User_talk:" . urlencode($appeal->getBlockingAdmin()), $user->getUseSecure()); ?>" target=\"_blank\"> User talk Page</a></li>
-  <li><a href="<?php echo getWikiLink("Special:EmailUser/" . urlencode($appeal->getBlockingAdmin()), $user->getUseSecure()); ?>" target=\"_blank\"> Email User</a></li>
+  <li><a href="<?php echo getWikiLink("User:" . $appeal->getBlockingAdmin(), $user->getUseSecure()); ?>" target=\"_blank\"><?php echo $appeal->getBlockingAdmin(); ?></a></li>
+  <li><a href="<?php echo getWikiLink("User_talk:" . $appeal->getBlockingAdmin(), $user->getUseSecure()); ?>" target=\"_blank\"> User talk Page</a></li>
+  <li><a href="<?php echo getWikiLink("Special:EmailUser/" . $appeal->getBlockingAdmin(), $user->getUseSecure()); ?>" target=\"_blank\"> Email User</a></li>
   </ul>
   </div>
 <?php if ($appeal->getHandlingAdmin()) {?>
 <div class="linklist">Reserved by:
 <ul>
 <li><a href="userMgmt.php?userId=<?php echo $appeal->getHandlingAdmin()->getUserId(); ?>"><?php echo $handlingAdmin = $appeal->getHandlingAdmin()->getUsername(); ?></a></li> 
-<li><a href="<?php echo getWikiLink("User:" . urlencode($appeal->getHandlingAdmin()->getWikiAccount()), $user->getUseSecure()); ?>" target=\"_blank\"> User Page</a></li> 
-<li><a href="<?php echo getWikiLink("User_talk:" . urlencode($appeal->getHandlingAdmin()->getWikiAccount()), $user->getUseSecure()); ?>" target=\"_blank\"> User talk Page</a></li> 
-<li><a href="<?php echo getWikiLink("Special:EmailUser/" . urlencode($appeal->getHandlingAdmin()->getWikiAccount()), $user->getUseSecure()); ?>" target=\"_blank\"> Email User</a></li>
+<li><a href="<?php echo getWikiLink("User:" . $appeal->getHandlingAdmin()->getWikiAccount(), $user->getUseSecure()); ?>" target=\"_blank\"> User Page</a></li> 
+<li><a href="<?php echo getWikiLink("User_talk:" . $appeal->getHandlingAdmin()->getWikiAccount(), $user->getUseSecure()); ?>" target=\"_blank\"> User talk Page</a></li> 
+<li><a href="<?php echo getWikiLink("Special:EmailUser/" . $appeal->getHandlingAdmin()->getWikiAccount(), $user->getUseSecure()); ?>" target=\"_blank\"> Email User</a></li>
 </ul>
 </div>
 <?php } ?>

--- a/public_html/src/appealObject.php
+++ b/public_html/src/appealObject.php
@@ -439,7 +439,7 @@ class Appeal{
 	
 	public function getUserPage() {
 		if ($this->accountName && $this->hasAccount) {
-			return "User:" . urlencode($this->accountName);
+			return "User:" . $this->accountName;
 		} else {
 			return "Special:Contributions/" . $this->ipAddress;
 		}

--- a/public_html/src/statsLib.php
+++ b/public_html/src/statsLib.php
@@ -92,7 +92,7 @@ function printAppealList(array $criteria = array(), $limit = "", $orderby = "", 
 			$requests .= "\t<tr class=\"" . $rowformat . "\">\n";
 			$requests .= "\t\t<td>" . $appeal->getID() . ".</td>\n";
 			$requests .= "\t\t<td><a style=\"color:green\" href='appeal.php?id=" . $appeal->getID() . "'>Zoom</a></td>\n";
-			$requests .= "\t\t<td><a style=\"color:blue\" href='" . getWikiLink($appeal->getUserPage(), $secure) . "' target='_NEW'>" . $appeal->getCommonName() . "</a></td>\n";
+			$requests .= "\t\t<td><a style=\"color:blue\" href='" . getWikiLink("user:".$appeal->getCommonName(), $secure) . "' target='_NEW'>" . $appeal->getCommonName() . "</a></td>\n";
 			if ($timestamp == 1) {
 				$requests .= "\t\t<td>" . $data['timestamp'] . "</td>\n";
 			}
@@ -201,7 +201,7 @@ function printRecentClosed() {
 			$requests .= "\t<tr class=\"" . $rowformat . "\">\n";
 			$requests .= "\t\t<td>" . $appeal->getID() . ".</td>\n";
 			$requests .= "\t\t<td><a style=\"color:green\" href='appeal.php?id=" . $appeal->getID() . "'>Zoom</a></td>\n";
-			$requests .= "\t\t<td><a style=\"color:blue\" href='" . getWikiLink($appeal->getUserPage(), $secure) . "' target='_NEW'>" . $appeal->getCommonName() . "</a></td>\n";
+			$requests .= "\t\t<td><a style=\"color:blue\" href='" . getWikiLink("user:" . $appeal->getCommonName(), $secure) . "' target='_NEW'>" . $appeal->getCommonName() . "</a></td>\n";
 			$requests .= "\t\t<td>" . $data['timestamp'] . "</td>\n";
 			$requests .= "\t</tr>\n";
 		}
@@ -271,7 +271,7 @@ function printBacklog() {
 			$requests .= "\t<tr class=\"" . $rowformat . "\">\n";
 			$requests .= "\t\t<td>" . $appeal->getID() . ".</td>\n";
 			$requests .= "\t\t<td><a style=\"color:green\" href='appeal.php?id=" . $appeal->getID(). "'>Zoom</a></td>\n";
-			$requests .= "\t\t<td><a style=\"color:blue\" href='" . getWikiLink($appeal->getUserPage(), $secure) . "' target='_NEW'>" . $appeal->getCommonName() . "</a></td>\n";
+			$requests .= "\t\t<td><a style=\"color:blue\" href='" . getWikiLink("user:" .$appeal->getCommonName(), $secure) . "' target='_NEW'>" . $appeal->getCommonName() . "</a></td>\n";
 			$requests .= "\t\t<td> " . $data['since_last_action'] . " days since last action</td>\n";
 			$requests .= "\t</tr>\n";
 		}

--- a/public_html/src/unblocklib.php
+++ b/public_html/src/unblocklib.php
@@ -237,8 +237,10 @@ function connectToDB($suppressOutput = false){
  *  as an associative array.
  */
 function getWikiLink($basepage, $useSecure = false, array $queryOptions = array()){
+	//trigger_error("basepage: $basepage");
+	//trigger_error("url encoded: " .urlencode($basepage));
 	$prefix = $useSecure ? "https:" : "http:";
-	$url = sprintf("%s//en.wikipedia.org/wiki/%s/", $prefix, urlencode($basepage));
+	$url = sprintf("%s//en.wikipedia.org/wiki/%s", $prefix, urlencode($basepage));
 	$first = true;
 	foreach($queryOptions as $key => $value){
 		$savekey = urlencode($key);


### PR DESCRIPTION
refactored getWikiLink to properly url encode.
This changes to signature of getWikiLink to take params as an associative array. Current uses have been converted, but should have decent beta testing. 
