### PR TITLE
Links to user info page in statistics + active users list

### DIFF
--- a/public_html/src/statsLib.php
+++ b/public_html/src/statsLib.php
@@ -528,7 +528,12 @@ function printLastThirtyActions() {
 		$styleTime = ($i%2 == 1) ? "largeLogTimeOne" : "largeLogTimeTwo";
 
 		$timestamp = (is_numeric($data['timestamp']) ? date("Y-m-d H:m:s", $data['timestamp']) : $data['timestamp']);
-		$username = ($data['commentUser']) ? User::getUserById($data['commentUser'])->getUserName() : Appeal::getAppealByID($data['appealID'])->getCommonName();
+		if ($data['commentUser']) {
+			$user = User::getUserById($data['commentUser']);
+			$username = "<a href=\"userMgmt.php?userId=" . $user->getUserId() . "\">" . $user->getUsername() . "</a>";
+		} else {
+			$username = Appeal::getAppealByID($data['appealID'])->getCommonName();
+		}
 		$italicsStart = ($data['action']) ? "<i>" : "";
 		$italicsEnd = ($data['action']) ? "</i>" : "";
 		$appeal = "<a href=\"appeal.php?id=" . $data['appealID'] . "\">" . Appeal::getAppealById($data['appealID'])->getCommonName() . "</a>";

--- a/public_html/src/unblocklib.php
+++ b/public_html/src/unblocklib.php
@@ -111,7 +111,7 @@ function getLoggedInUsers(){
 	
 	while (($data = $query->fetch(PDO::FETCH_ASSOC)) !== false) {
 		$user = User::getUserById($data['userID']);
-		$users[] = $user->getUsername();
+		$users[] = "<a href=\"userMgmt.php?userId=" . $user->getUserId() . "\">" . $user->getUsername() . "</a>";
 	}
 	
 	return implode(', ', $users);


### PR DESCRIPTION
This'll put links to the user info page (`userMgmt.php`) in the statistics page and active users list at the bottom of every page, [like so](http://i.imgur.com/QiqaU.png).

The appeal pages already show these links, so it makes sense that they should be accessible from other locations.
