### PR TITLE
Only require "User_talk" in the confirmation link (not a ':')

### DIFF
--- a/public_html/register.php
+++ b/public_html/register.php
@@ -97,9 +97,9 @@ if(isset($_POST["submit"])){
 			$errorMessages .= ($errorMessages ? '\n' : '') . 'A confirmation diff link is required.';
 		}
 		$urlWikiAccount = urlencode(str_replace(" ", "_", $wikiAccount));
-		if(strpos($diff, "diff") === false || strpos($diff, "User_talk:" . $urlWikiAccount) === false){
+		if(strpos($diff, "diff") === false || strpos($diff, "User_talk" . $urlWikiAccount) === false){
 			$errorMessages .= ($errorMessages ? '\n' : '') . 'You must provide a valid confirmation diff to your user talk page. Please note ' .
-				'that this form requires that "title=User_talk:[...]" be included in your diff link.';
+				'that this form requires that "title=User_talk[...]" be included in your diff link.';
 		}
 		
 		if(!$errorMessages){


### PR DESCRIPTION
Some browsers (Firefox) will automatically encode the :, meaning that it won't match and will generate an error.
