### PR TITLE
IPv6 message

### DIFF
--- a/public_html/index.php
+++ b/public_html/index.php
@@ -91,10 +91,10 @@ if(isset($_POST["submit"])){
         throw new UTRSValidationException('The username you entered ('.$wikiAccount.') is not currently blocked. Please verify that you are blocked by following the instructions above.');
       }
       elseif ($registered && $autoblock  && !Appeal::verifyBlock($ip, FALSE)) {
-        throw new UTRSValidationException('Your IP Address ('.$ip.') is not currently blocked. Is it your account that is blocked?');
+        throw new UTRSValidationException('Your IP Address ('.$ip.') is not currently blocked. If you are affected by an IPv6 block, please send a message to the mailing list instead (see at the bottom of the page). Is it your account that is blocked?');
       }
       elseif (!$registered && !Appeal::verifyBlock($ip, FALSE)) {
-        throw new UTRSValidationException('Your IP Address ('.$ip.') is not currently blocked. If you have an account, please select \'Yes\' to "Do you have an account on Wikipedia?".');
+        throw new UTRSValidationException('Your IP Address ('.$ip.') is not currently blocked. If you are affected by an IPv6 block, please send a message to the mailing list instead (see at the bottom of the page). If you have an account, please select \'Yes\' to "Do you have an account on Wikipedia?".');
       }
       if ($registered && !Appeal::verifyNoPublicAppeal($wikiAccount)) {
         throw new UTRSValidationException('You are currently appealing your block on your talkpage. The UTRS team does not hear appeals already in the process of being reviewed.');


### PR DESCRIPTION
Until we can support IPv6 (#139) we should at least provide some instructions as to what users should do instead of having them jump through hoops in the more unconventional of ways (see ticket 20206.......); feel free to reword as desired.

The other thing that needs addressing is global blocks but these should be directed to Meta and not the mailing list and I think they should be detectable in the same way as enwiki blocks are thus it would require actual coding of that