### PR TITLE
Update reply.php

### DIFF
--- a/public_html/reply.php
+++ b/public_html/reply.php
@@ -102,7 +102,7 @@ try{
       
       //Email notification to the admin handling the appeal
       
-      if ($admin->replyNotify()) {
+      if ($admin && $admin->replyNotify()) {
          $email = $admin->getEmail();
          $headers = "From: Unblock Review Team <noreply-unblock@toolserver.org>\r\n";
          $headers .= "MIME-Version: 1.0\r\n";


### PR DESCRIPTION
Fix error when admin releases appeal before user makes a reply

Fatal error: Call to a member function replyNotify() on a non-object in /usr/utrs/production/public_html/reply.php on line 105