### PR TITLE
Update template.php: Change www.google.com/recaptcha to www.recaptcha.net/recaptcha

### DIFF
--- a/public_html/template.php
+++ b/public_html/template.php
@@ -42,7 +42,7 @@ if($loggedIn){
    echo "<script type=\"text/javascript\">" . $script . "</script>";
 }
 if($recaptcha){
-   echo '<script src="https://www.google.com/recaptcha/api.js" async defer></script>';
+   echo '<script src="https://www.recaptcha.net/recaptcha/api.js" async defer></script>';
 }
 ?>
 <style>


### PR DESCRIPTION
Change www.google.com/recaptcha to www.recaptcha.net/recaptcha for global use since some of the countries have blocked google.com, and www.recaptcha.net is much more accessible around the globe.

I am a wikipedian from mainland China and I've taken part in a WIkipedia-related QQ group to help those newcomers. The access of Wikipedia from mainland China is sometimes difficult and they might apply for IPBE through UTRS. The blockade of reCAPTCHA might be a barrier. 