### PR TITLE
Change OAuth url to enwiki

### DIFF
--- a/public_html/login.php
+++ b/public_html/login.php
@@ -57,7 +57,7 @@ debug('Destination: ' . $destination . '  Logout: ' . $logout . '</br>');
  * Set this to the Special:OAuth/authorize URL. 
  * To work around MobileFrontend redirection, use /wiki/ rather than /w/index.php.
  */
-$mwOAuthAuthorizeUrl = 'https://www.mediawiki.org/wiki/Special:OAuth/authorize';
+$mwOAuthAuthorizeUrl = 'https://en.wikipedia.org/wiki/Special:OAuth/authorize';
 
 /**
  * Set this to the Special:OAuth URL. 


### PR DESCRIPTION
With the deployment of 1.35wmf30 we had a struggle with E004 errors. Because UTRS is such a high demand application, we should remain only on the most stable versions of wiki software, which enwiki is one of the last to deploy to.